### PR TITLE
Responsive

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,7 +11,7 @@
 </head>
 <body>
   <div class="topContainer flexColumn">
-    <div class="omikujiPaper flexColumn">
+    <div class="omikujiPaper flexColumn aboutContents">
       <h3>このおみくじについて</h3>
       <ul>
         <li>このおみくじは、コンピュータ・サイエンスの学習プラットフォーム<a href="https://recursionist.io" target="_blank" rel="noopener noreferrer">Recursion</a>で開催されているイベント「チーム開発体験会」の課題として制作されたものです。</li>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>おみくじ</title>
+  <title>おみくじ遊び</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&family=Noto+Sans+JP:wght@100..900&family=Playwrite+DK+Uloopet:wght@100..400&family=Yuji+Syuku&display=swap" rel="stylesheet">
@@ -12,7 +12,7 @@
 <body>
   <div class="topContainer flexColumn">
     <div id="topPage" class="d-block omikujiBox">
-      <h1 class="topTitle">おみくじ</h1>
+      <h1 class="topTitle">おみくじ遊び</h1>
       <img src="img/omikuji.PNG" alt="おみくじのイラスト">
       <button id="drawButton" class="omikujiButton">おみくじを引く</button>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -141,14 +141,9 @@ footer p {
   .omikujiPaper {
     width: 280px;
   }
-  .aboutContents {
-    height: auto;
-    padding: 16px;
-    overflow: hidden;
-  }
 }
 
-@media screen and (min-height: 520px) {
+@media screen and (min-height: 560px) {
   #topPage {
     margin: 0 0 1em 0;
   }
@@ -157,5 +152,10 @@ footer p {
   }
   #drawButton {
     margin: 1.5em 0 2em 0;
+  }
+  .aboutContents {
+    height: auto;
+    padding: 16px;
+    overflow: hidden;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -4,8 +4,6 @@
   text-decoration: none;
   box-sizing: border-box;
   font-family: "Yuji Syuku", serif;
-  /* font-weight: 400; */
-  /* font-style: normal; */
 }
 
 :root {
@@ -110,7 +108,7 @@ hr {
   width: 100%;
 }
 #fortuneComment {
-  font-size: .9em;
+  font-size: .9rem;
   text-align: left;
 }
 #reTryButton {
@@ -135,6 +133,7 @@ footer p {
   overflow-y: scroll;
   justify-content: normal;
 }
+
 @media screen and (min-width: 320px) {
   .topTitle {
     font-size: 2.4rem;
@@ -160,5 +159,3 @@ footer p {
     margin: 1.5em 0 2em 0;
   }
 }
-
-/* 230×425 px */

--- a/styles.css
+++ b/styles.css
@@ -35,25 +35,26 @@
 }
 
 /* ページ全体 */
+html, body {
+  height: 100%;
+}
 .topContainer {
   width: 100%;
-  height: 100vh;
+  height: 100%;
   text-align: center;
   color: var(--main-text-color);
   background: linear-gradient(#feebd2, #fcb8a1);
 }
 
 /* トップのおみくじ */
-#topPage {
-  margin: 1em 0;
-}
 .omikujiBox img {
   width: 50%;
-  margin: 2em 0 1em 0;
+  min-width: 100px;
+  margin: 1em 0;
   filter: drop-shadow(0 0 16px var(--white));
 }
 #drawButton {
-  margin: 1.5em 0 2em 0;
+  margin-bottom: 1em;
 }
 
 /* 共通ボタンスタイル */
@@ -77,24 +78,22 @@
 
 /* おみくじの紙ページ */
 .omikujiPaper {
+  width: 80%;
   padding: 16px;
-  width: 280px;
   border: thick double var(--red);
   outline: .2rem solid var(--red);
   background-color: var(--white);
   margin-bottom: 1em;
 }
 .omikujiPaper h3,
-.omikujiPaper h4 {
+.omikujiPaper h4,
+.omikujiPaper ul li {
   margin-bottom: 1em;
 }
 .omikujiPaper ul {
   list-style: square;
   text-align: left;
   padding: 0 .5em 0 2em;
-}
-.omikujiPaper ul li {
-  margin-bottom: 1em;
 }
 
 /* おみくじの結果ページ */
@@ -107,15 +106,15 @@ hr {
   border-top: 2px solid var(--red-translucent);
   margin: 1em 0;
 }
-#reTryButton {
-  margin: 1.5em 0 0 0;
-}
 #resultImg {
   width: 100%;
 }
 #fortuneComment {
   font-size: .9em;
   text-align: left;
+}
+#reTryButton {
+  margin-top: 1.5em;
 }
 
 /* フッター */
@@ -129,3 +128,37 @@ footer p {
   font-size: .5rem;
   margin-top: 2em;
 }
+
+/* レスポンシブ対応 */
+.aboutContents {
+  height: 64vh;
+  overflow-y: scroll;
+  justify-content: normal;
+}
+@media screen and (min-width: 320px) {
+  .topTitle {
+    font-size: 2.4rem;
+  }
+  .omikujiPaper {
+    width: 280px;
+  }
+  .aboutContents {
+    height: auto;
+    padding: 16px;
+    overflow: hidden;
+  }
+}
+
+@media screen and (min-height: 520px) {
+  #topPage {
+    margin: 0 0 1em 0;
+  }
+  .omikujiBox img {
+    margin: 2em 0 1em 0;
+  }
+  #drawButton {
+    margin: 1.5em 0 2em 0;
+  }
+}
+
+/* 230×425 px */


### PR DESCRIPTION
レスポンシブ対応をしました。
- 230×425 pxまでデザイン崩れしないことを確認しました。
- 戻るボタンの固定について：おみくじ結果のページと同様に説明文をoverflow: scroll;にすることで、 ページの下部に常に戻るボタンが表示されるようにしました。