### PR TITLE
add open graph protocol property

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="おみくじの運勢で体の大きさが変わる、不思議なアヒルの「きち」と一緒に遊ぶことができます。">
+  <!-- Open Graph Protocol -->
+  <meta property="og:title" content="おみくじ遊び">
+  <meta property="og:description" content="おみくじの運勢で体の大きさが変わる、不思議なアヒルの「きち」と一緒に遊ぶことができます。">
+  <meta property="og:image" content="assets/images/omikuji.PNG">
   <title>このおみくじについて</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -26,6 +30,5 @@
       <p>©︎おみくじ</p>
     </footer>
   </div>
-  <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="おみくじの運勢で体の大きさが変わる、不思議なアヒルの「きち」と一緒に遊ぶことができます。">
+  <!-- Open Graph Protocol -->
+  <meta property="og:title" content="おみくじ遊び">
+  <meta property="og:description" content="おみくじの運勢で体の大きさが変わる、不思議なアヒルの「きち」と一緒に遊ぶことができます。">
+  <meta property="og:image" content="assets/images/omikuji.PNG">
   <title>開発者一覧</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -28,6 +32,5 @@
       <p>©︎おみくじ</p>
     </footer>
   </div>
-  <script src="assets/js/main.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="おみくじの運勢で体の大きさが変わる、不思議なアヒルの「きち」と一緒に遊ぶことができます。">
+  <!-- Open Graph Protocol -->
+  <meta property="og:title" content="おみくじ遊び">
+  <meta property="og:description" content="おみくじの運勢で体の大きさが変わる、不思議なアヒルの「きち」と一緒に遊ぶことができます。">
+  <meta property="og:image" content="assets/images/omikuji.PNG">
   <title>おみくじ遊び</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
LINEでの表示（display:none;のおみくじが説明文として表示されてしまう現象）に効果がなかったため、Open Graph Protocolの記述を追加しました。
また、JavaScriptを使用していないabout.htmlとdevelopers.htmlのscriptタグを削除しました。